### PR TITLE
Modifications to make the ModdedSongsManager handle reloads

### DIFF
--- a/TekaTeka/Plugins/CustomSongLoader.cs
+++ b/TekaTeka/Plugins/CustomSongLoader.cs
@@ -100,6 +100,15 @@ namespace TekaTeka.Plugins
             }
         }
 
+        [HarmonyPatch(typeof(MusicDataInterface))]
+        [HarmonyPatch(nameof(MusicDataInterface.Reload))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPostfix]
+        public static void MusicDataInterface_Reload_Postfix(MusicDataInterface __instance) {
+            // The music data manager has been reset, so we need to publish the mod songs.
+            songsManager.PublishSongs();
+        }
+
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Scripts.UserData.UserData), nameof(Scripts.UserData.UserData.FixData))]
         static void PatchLoad(ref Scripts.UserData.UserData __instance)

--- a/TekaTeka/Utils/FumenSongMod.cs
+++ b/TekaTeka/Utils/FumenSongMod.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using TekaTeka.Plugins;
 using Tommy;
+using static MusicDataInterface;
 
 namespace TekaTeka.Utils
 {
@@ -143,22 +144,14 @@ namespace TekaTeka.Utils
             {
                 MusicDataInterface.MusicInfo song = this.songList[i];
                 if (!manager.currentSongs.Contains(song.UniqueId))
-                {
+                { 
                     songsAdded++;
 
-                    manager.currentSongs.Add(song.UniqueId);
-                    manager.songFileToMod.Add(song.SongFileName, this);
-                    manager.uniqueIdToMod.Add(song.UniqueId, this);
-                    manager.idToMod.Add(song.Id, this);
                     var entry = new FumenSongEntry(this.modFolder, song);
                     this.chartFileToEntry.Add(song.Id, entry);
                     this.songFileToEntry.Add(song.SongFileName, entry);
 
-                    manager.initialPossessionData.InitialPossessionInfoAccessers.Add(
-                        new InitialPossessionDataInterface.InitialPossessionInfoAccessor(
-                            (int)InitialPossessionDataInterface.RewardTypes.Song, song.UniqueId));
-
-                    manager.musicData.AddMusicInfo(ref song);
+                    manager.RetainMusicInfo(song, this);
                 }
                 else
                 {

--- a/TekaTeka/Utils/ModdedSongsManager.cs
+++ b/TekaTeka/Utils/ModdedSongsManager.cs
@@ -1,6 +1,7 @@
 using Scripts.UserData;
 using Scripts.UserData.Flag;
 using TekaTeka.Plugins;
+using static MusicDataInterface;
 
 namespace TekaTeka.Utils
 {
@@ -10,6 +11,8 @@ namespace TekaTeka.Utils
         public Dictionary<int, SongMod> uniqueIdToMod = new Dictionary<int, SongMod>();
         public Dictionary<string, SongMod> idToMod = new Dictionary<string, SongMod>();
         public Dictionary<string, SongMod> songFileToMod = new Dictionary<string, SongMod>();
+        public List<MusicDataInterface.MusicInfo> musicInfos = new List<MusicDataInterface.MusicInfo>();
+
         public MusicDataInterface musicData => TaikoSingletonMonoBehaviour<DataManager>.Instance.MusicData;
         public InitialPossessionDataInterface initialPossessionData =>
             TaikoSingletonMonoBehaviour<DataManager>.Instance.InitialPossessionData;
@@ -26,6 +29,7 @@ namespace TekaTeka.Utils
                 this.currentSongs.Add(accesser.UniqueId);
             }
             this.SetupMods();
+            this.PublishSongs();
         }
 
         public List<SongMod> GetMods()
@@ -92,6 +96,24 @@ namespace TekaTeka.Utils
                         }
                     }
                 }
+            }
+        }
+
+        public void RetainMusicInfo(MusicDataInterface.MusicInfo musicInfo, SongMod mod) {
+            this.currentSongs.Add(musicInfo.UniqueId);
+            this.songFileToMod.Add(musicInfo.SongFileName, mod);
+            this.uniqueIdToMod.Add(musicInfo.UniqueId, mod);
+            this.idToMod.Add(musicInfo.Id, mod);
+            this.musicInfos.Add(musicInfo);
+            this.initialPossessionData.InitialPossessionInfoAccessers.Add(
+                new InitialPossessionDataInterface.InitialPossessionInfoAccessor(
+                    (int)InitialPossessionDataInterface.RewardTypes.Song, musicInfo.UniqueId));
+        }
+
+        public void PublishSongs() {
+            for (int i = 0; i < this.musicInfos.Count; i++) {
+                var tmp = this.musicInfos[i];
+                this.musicData.AddMusicInfo(ref tmp);
             }
         }
 

--- a/TekaTeka/Utils/TjaSongMod.cs
+++ b/TekaTeka/Utils/TjaSongMod.cs
@@ -99,20 +99,7 @@ namespace TekaTeka.Utils
 
         public override void AddMod(ModdedSongsManager manager)
         {
-            var musicInfo = this.song.musicInfo;
-
-            var tjaSong = tja2fumen.Parsers.ParseTja(this.tjaPath);
-            uint songHash = _3rdParty.MurmurHash2.Hash(File.ReadAllBytes(this.tjaPath)) & 0xFFFF_FFF;
-            manager.currentSongs.Add(this.uniqueId);
-            manager.songFileToMod.Add($"SONG_{songHash}", this);
-            manager.uniqueIdToMod.Add(this.uniqueId, this);
-
-            manager.idToMod.Add(songHash.ToString(), this);
-            manager.musicData.AddMusicInfo(ref musicInfo);
-
-            manager.initialPossessionData.InitialPossessionInfoAccessers.Add(
-                new InitialPossessionDataInterface.InitialPossessionInfoAccessor(
-                    (int)InitialPossessionDataInterface.RewardTypes.Song, musicInfo.UniqueId));
+            manager.RetainMusicInfo(this.song.musicInfo, this);
         }
 
         public override SongEntry GetSongEntry(string id, bool idIsSongFile = false)


### PR DESCRIPTION
This splits the construction of the manager into two parts. The first part does the one-time load of the mods in TekaSongs, handling Fumen and TJA songs. The second part, called "publishing" handles the process of making the mods available to the music data of the game. This needs to be called at startup and whenever a Reload() occurs, which is handled with a postfix patch.

Manager functionality that was repeated in both the TJA and Fumen mods was consolidated into a single method.

Tested this change with and without the SwapSongLanguages, verifying that both Fumen and TJA mods were present, and that the SwapSongLanguages mod worked as expected.