### PR TITLE
Fix crash when official song conflicts with TekaTeka mod.

### DIFF
--- a/TekaTeka/Plugins/CustomSongLoader.cs
+++ b/TekaTeka/Plugins/CustomSongLoader.cs
@@ -5,6 +5,7 @@ using System.Text;
 using TekaTeka.Utils;
 using Scripts.UserData;
 using Il2CppSystem.Security.Cryptography;
+using static MusicDataInterface;
 
 namespace TekaTeka.Plugins
 {
@@ -104,9 +105,27 @@ namespace TekaTeka.Plugins
         [HarmonyPatch(nameof(MusicDataInterface.Reload))]
         [HarmonyPatch(MethodType.Normal)]
         [HarmonyPostfix]
-        public static void MusicDataInterface_Reload_Postfix(MusicDataInterface __instance) {
+        public static void MusicDataInterface_Reload_Postfix(MusicDataInterface __instance)
+        {
             // The music data manager has been reset, so we need to publish the mod songs.
             songsManager.PublishSongs();
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(MusicDataInterface), nameof(MusicDataInterface.AddMusicInfo))]
+        public static bool MusicDataInterface_AddMusicInfo_Prefix(MusicDataInterface __instance, ref MusicInfo musicinfo)
+        {
+            if (songsManager == null)
+            {
+                return true;
+            }
+            if (songsManager.idToMod.ContainsKey(musicinfo.Id))
+            {
+                Logger.Log($"Removing new song: {musicinfo.Id}: official ID: {musicinfo.UniqueId}");
+                var mod = songsManager.idToMod[musicinfo.Id];
+                mod.RemoveMod(musicinfo.Id, songsManager);
+            }
+            return true;
         }
 
         [HarmonyPrefix]

--- a/TekaTeka/Plugins/CustomSongLoader.cs
+++ b/TekaTeka/Plugins/CustomSongLoader.cs
@@ -113,16 +113,17 @@ namespace TekaTeka.Plugins
 
         [HarmonyPrefix]
         [HarmonyPatch(typeof(MusicDataInterface), nameof(MusicDataInterface.AddMusicInfo))]
-        public static bool MusicDataInterface_AddMusicInfo_Prefix(MusicDataInterface __instance, ref MusicInfo musicinfo)
+        public static bool MusicDataInterface_AddMusicInfo_Prefix(MusicDataInterface __instance,
+                                                                  ref MusicInfo musicinfo)
         {
             if (songsManager == null)
             {
                 return true;
             }
-            if (songsManager.idToMod.ContainsKey(musicinfo.Id))
+            SongMod? mod = songsManager.GetModFromId(musicinfo.Id);
+            if (mod != null)
             {
                 Logger.Log($"Removing new song: {musicinfo.Id}: official ID: {musicinfo.UniqueId}");
-                var mod = songsManager.idToMod[musicinfo.Id];
                 mod.RemoveMod(musicinfo.Id, songsManager);
             }
             return true;

--- a/TekaTeka/Utils/FumenSongMod.cs
+++ b/TekaTeka/Utils/FumenSongMod.cs
@@ -2,7 +2,6 @@
 using System.Text;
 using TekaTeka.Plugins;
 using Tommy;
-using static MusicDataInterface;
 
 namespace TekaTeka.Utils
 {
@@ -136,15 +135,24 @@ namespace TekaTeka.Utils
                 return songEntry;
             }
         }
-
+        public override void RemoveMod(string songId, ModdedSongsManager manager)
+        {
+            MusicDataInterface.MusicInfo? target = this.songList.Find(hit => hit.Id == songId);
+            if (target != null)
+            {
+                Logger.Log($"Removing Fumen mod '{modName}' song id {target.UniqueId}");
+                manager.RemoveMusicInfo(target);
+            }
+        }
         public override void AddMod(ModdedSongsManager manager)
         {
             int songsAdded = 0;
             for (int i = 0; i < this.songList.Count; i++)
             {
                 MusicDataInterface.MusicInfo song = this.songList[i];
+
                 if (!manager.currentSongs.Contains(song.UniqueId))
-                { 
+                {
                     songsAdded++;
 
                     var entry = new FumenSongEntry(this.modFolder, song);

--- a/TekaTeka/Utils/ModdedSongsManager.cs
+++ b/TekaTeka/Utils/ModdedSongsManager.cs
@@ -1,13 +1,15 @@
 using Scripts.UserData;
 using Scripts.UserData.Flag;
 using TekaTeka.Plugins;
-using static MusicDataInterface;
 
 namespace TekaTeka.Utils
 {
     internal class ModdedSongsManager
     {
+        // Current songs is all music identifiers: core content, DLC, and mods.
         public HashSet<int> currentSongs = new HashSet<int>();
+        // Other data structures only hold information about mods. musicInfos should
+        // not contain MusicInfo for non-mod content.
         public Dictionary<int, SongMod> uniqueIdToMod = new Dictionary<int, SongMod>();
         public Dictionary<string, SongMod> idToMod = new Dictionary<string, SongMod>();
         public Dictionary<string, SongMod> songFileToMod = new Dictionary<string, SongMod>();
@@ -23,7 +25,6 @@ namespace TekaTeka.Utils
 
         public ModdedSongsManager()
         {
-
             foreach (MusicDataInterface.MusicInfoAccesser accesser in musicData.MusicInfoAccesserList)
             {
                 this.currentSongs.Add(accesser.UniqueId);
@@ -99,7 +100,19 @@ namespace TekaTeka.Utils
             }
         }
 
-        public void RetainMusicInfo(MusicDataInterface.MusicInfo musicInfo, SongMod mod) {
+        public void RemoveMusicInfo(MusicDataInterface.MusicInfo musicInfo)
+        {
+            this.currentSongs.Remove(musicInfo.UniqueId);
+            this.songFileToMod.Remove(musicInfo.Id);
+            this.uniqueIdToMod.Remove(musicInfo.UniqueId);
+            this.idToMod.Remove(musicInfo.Id);
+            this.musicInfos.Remove(musicInfo);
+            musicData.RemoveMusicInfo(musicInfo.UniqueId);
+            musicData.SortByOrder();
+        }
+
+        public void RetainMusicInfo(MusicDataInterface.MusicInfo musicInfo, SongMod mod)
+        {
             this.currentSongs.Add(musicInfo.UniqueId);
             this.songFileToMod.Add(musicInfo.SongFileName, mod);
             this.uniqueIdToMod.Add(musicInfo.UniqueId, mod);
@@ -110,11 +123,14 @@ namespace TekaTeka.Utils
                     (int)InitialPossessionDataInterface.RewardTypes.Song, musicInfo.UniqueId));
         }
 
-        public void PublishSongs() {
-            for (int i = 0; i < this.musicInfos.Count; i++) {
+        public void PublishSongs()
+        {
+            for (int i = 0; i < this.musicInfos.Count; i++)
+            {
                 var tmp = this.musicInfos[i];
                 this.musicData.AddMusicInfo(ref tmp);
             }
+            this.musicData.SortByOrder();
         }
 
         public void SetupMods()

--- a/TekaTeka/Utils/ModdedSongsManager.cs
+++ b/TekaTeka/Utils/ModdedSongsManager.cs
@@ -161,18 +161,38 @@ namespace TekaTeka.Utils
 
         public SongMod? GetModPath(string songFileName)
         {
-            if (this.songFileToMod.ContainsKey(songFileName))
+            SongMod? songMod = null;
+            songMod = this.GetModFromSongFile(songFileName);
+            if (songMod != null)
             {
-                return this.songFileToMod[songFileName];
+                return songMod;
             }
-            else if (this.idToMod.ContainsKey(songFileName))
+
+            songMod = this.GetModFromId(songFileName);
+            if (songMod != null)
             {
-                return this.idToMod[songFileName];
+                return songMod;
             }
-            else
+
+            return null;
+        }
+
+        public SongMod? GetModFromId(string songId)
+        {
+            if (!this.idToMod.ContainsKey(songId))
             {
                 return null;
             }
+            return this.idToMod[songId];
+        }
+
+        public SongMod? GetModFromSongFile(string songFile)
+        {
+            if (!this.songFileToMod.ContainsKey(songFile))
+            {
+                return null;
+            }
+            return this.songFileToMod[songFile];
         }
 
         public UserData FilterModdedData(UserData userData)

--- a/TekaTeka/Utils/SongEntry.cs
+++ b/TekaTeka/Utils/SongEntry.cs
@@ -1,6 +1,4 @@
-﻿using AsmResolver;
-
-namespace TekaTeka.Utils
+﻿namespace TekaTeka.Utils
 {
     internal abstract class SongEntry
     {

--- a/TekaTeka/Utils/SongMod.cs
+++ b/TekaTeka/Utils/SongMod.cs
@@ -179,7 +179,7 @@ namespace TekaTeka.Utils
         protected string modFolder { get; set; }
 
         public abstract void AddMod(ModdedSongsManager manager);
-
+        public abstract void RemoveMod(string songId, ModdedSongsManager manager);
         public abstract bool IsValidMod();
 
         public string GetModFolder()

--- a/TekaTeka/Utils/TjaSongMod.cs
+++ b/TekaTeka/Utils/TjaSongMod.cs
@@ -102,6 +102,11 @@ namespace TekaTeka.Utils
             manager.RetainMusicInfo(this.song.musicInfo, this);
         }
 
+        public override void RemoveMod(string unused, ModdedSongsManager manager)
+        {
+            manager.RemoveMusicInfo(this.song.musicInfo);
+        }
+
         public override SongEntry GetSongEntry(string id, bool idIsSongFile = false)
         {
             song.songFile = id;


### PR DESCRIPTION
Hooked AddMusic to check for a mod that conflicts with a song being added. If this happens, the mod is removed allowing the original content to be installed. Log information is available for mod developers to update their mod.